### PR TITLE
feature/add-http-interceptor-to-add-access-token-to-all-request-or-refresh-it-when-expire

### DIFF
--- a/src/app/security/auth.interceptor.spec.ts
+++ b/src/app/security/auth.interceptor.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpInterceptorFn } from '@angular/common/http';
+
+import { authInterceptor } from './auth.interceptor';
+
+describe('authInterceptor', () => {
+  const interceptor: HttpInterceptorFn = (req, next) => 
+    TestBed.runInInjectionContext(() => authInterceptor(req, next));
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+  });
+
+  it('should be created', () => {
+    expect(interceptor).toBeTruthy();
+  });
+});

--- a/src/app/security/auth.interceptor.ts
+++ b/src/app/security/auth.interceptor.ts
@@ -1,0 +1,37 @@
+import { HttpInterceptorFn } from '@angular/common/http';
+import {inject} from '@angular/core';
+import {OAuthService} from 'angular-oauth2-oidc';
+import {catchError, from, switchMap, throwError} from 'rxjs';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const oauthService = inject(OAuthService);
+  const token = oauthService.getAccessToken();
+
+  if (token && oauthService.hasValidAccessToken()) {
+    const authReq = req.clone({
+      setHeaders: { Authorization: `Bearer ${token}` }
+    });
+    return next(authReq);
+  }
+
+  const refreshToken = oauthService.getRefreshToken();
+
+  if (refreshToken) {
+    return from(oauthService.refreshToken()).pipe(
+      switchMap(() => {
+        const newToken = oauthService.getAccessToken();
+        const authReq = req.clone({
+          setHeaders: { Authorization: `Bearer ${newToken}` }
+        });
+        return next(authReq);
+      }),
+      catchError((error) => {
+        console.error('Refresh token failed', error);
+        oauthService.logOut();
+        return throwError(() => error);
+      })
+    );
+  }
+
+  return next(req);
+};


### PR DESCRIPTION
Every request is intercepted by the http interceptor and access token is added as a header. 
If the access token is expired, refresh token is used to get a new access token.