### PR TITLE
feature/add-users-and-markers-rankings

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,4 +1,4 @@
-import { Routes } from '@angular/router';
+import {Routes} from '@angular/router';
 import {CallbackComponent} from './components/callback/callback.component';
 import {LoginComponent} from './components/login/login.component';
 import {authGuard} from './security/auth.guard';
@@ -7,11 +7,12 @@ import {RegisterComponent} from './components/register/register.component';
 import {MarkerDetailComponent} from './components/marker-detail/marker-detail.component';
 import {ShellComponent} from './components/shell/shell.component';
 import {ProfileComponent} from './components/profile/profile.component';
+import {RankingsPageComponent} from './components/rankings-page/rankings-page.component';
 
 export const routes: Routes = [
-  { path: '', component: LoginComponent },
-  { path: 'callback', component: CallbackComponent },
-  { path: 'register', component: RegisterComponent },
+  {path: '', component: LoginComponent, pathMatch: 'full'},
+  {path: 'callback', component: CallbackComponent},
+  {path: 'register', component: RegisterComponent},
   {
     path: '',
     component: ShellComponent,
@@ -21,8 +22,8 @@ export const routes: Routes = [
         path: 'home',
         component: HomeComponent,
         children: [
-          { path: 'marker/:id', component: MarkerDetailComponent, outlet: 'detail' },
-          { path: 'marker/new', component: MarkerDetailComponent, outlet: 'detail' }
+          {path: 'marker/:id', component: MarkerDetailComponent, outlet: 'detail'},
+          {path: 'marker/new', component: MarkerDetailComponent, outlet: 'detail'}
         ]
       },
       {
@@ -31,9 +32,10 @@ export const routes: Routes = [
           import('./components/user-public/user-public.component')
             .then(m => m.UserPublicComponent)
       },
-      { path: 'profile', component: ProfileComponent },
-      { path: '', pathMatch: 'full', redirectTo: 'home' }
+      {path: 'profile', component: ProfileComponent},
+      {path: 'ranking', component: RankingsPageComponent},
+      {path: '', pathMatch: 'full', redirectTo: 'home'}
     ]
   },
-  { path: '**', redirectTo: '' }
+  {path: '**', redirectTo: ''}
 ];

--- a/src/app/components/rankings-page/rankings-page.component.css
+++ b/src/app/components/rankings-page/rankings-page.component.css
@@ -1,0 +1,207 @@
+.container {
+  --col-rank: 3.2rem;
+  --col-metric: 9.75rem;
+  --col-metric-wide: 12rem;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 0 12px 40px;
+}
+
+.controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: .75rem;
+  margin-bottom: .5rem;
+}
+
+.group {
+  display: flex;
+  gap: .5rem;
+}
+
+.tabs button, .subtabs button {
+  border: none;
+  background: #f2f2f2;
+  padding: .5rem .75rem;
+  border-radius: .6rem;
+  cursor: pointer;
+}
+
+.tabs button.active, .subtabs button.active {
+  background: #111;
+  color: #fff;
+}
+
+.explainer {
+  display: flex;
+  align-items: center;
+  gap: .5rem;
+  font-size: .95rem;
+  color: #555;
+  margin-bottom: .75rem;
+}
+
+.explainer .info {
+  font-size: 18px;
+  opacity: .8;
+}
+
+.explainer .link {
+  background: transparent;
+  border: none;
+  color: #111;
+  cursor: pointer;
+  margin-left: auto;
+  text-decoration: underline;
+  font-weight: 600;
+}
+
+.list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: .6rem;
+}
+
+.row {
+  display: grid;
+  grid-template-columns:
+    var(--col-rank)
+    minmax(0, 1fr)
+    var(--col-metric)
+    var(--col-metric)
+    var(--col-metric-wide);
+  align-items: center;
+  column-gap: 1rem;
+  row-gap: 0;
+  padding: .75rem .9rem;
+  border: 1px solid #eee;
+  border-radius: .8rem;
+  background: #fff;
+  min-height: 64px;
+}
+
+.cell.rank {
+  font-weight: 700;
+  text-align: center;
+}
+
+.cell.who {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  min-width: 0;
+}
+
+.avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.name {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.cell.metric {
+  justify-self: end;
+  width: 100%;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.cell.metric.hidden {
+  visibility: hidden;
+}
+
+.metric-chip {
+  width: 100%;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: .5rem;
+  padding: .35rem .6rem;
+  border-radius: .6rem;
+
+  background: #f5f5f5;
+  --mdc-chip-elevated-container-color: #f5f5f5;
+  --mdc-chip-label-text-color: inherit;
+  --mdc-chip-label-text-size: .9rem;
+}
+
+.metric-chip.mat-mdc-chip {
+  margin: 0 !important;
+}
+
+.metric-chip mat-icon {
+  font-size: 18px;
+  height: 18px;
+  width: 18px;
+}
+
+.metric-chip .label {
+  opacity: .75;
+}
+
+.metric-chip .value {
+  font-weight: 600;
+  margin-left: .25rem;
+}
+
+.metric-chip.accent {
+  background: #e9f7ef;
+  --mdc-chip-elevated-container-color: #e9f7ef;
+}
+
+.actions {
+  display: flex;
+  justify-content: center;
+  margin-top: 28px;
+}
+
+.error {
+  color: #c62828;
+}
+
+@media (max-width: 720px) {
+  .row {
+    grid-template-columns: var(--col-rank) 1fr;
+    grid-auto-rows: auto;
+  }
+
+  .cell.metric {
+    justify-self: start;
+  }
+
+  .metric-chip {
+    width: auto;
+  }
+}
+
+a.link {
+  color: inherit;
+  text-decoration: none;
+}
+
+a.link:hover .name, .btn-like:hover .name {
+  text-decoration: underline;
+}
+
+.btn-like {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+}
+
+.btn-like:focus {
+  outline: none;
+}

--- a/src/app/components/rankings-page/rankings-page.component.html
+++ b/src/app/components/rankings-page/rankings-page.component.html
@@ -1,0 +1,121 @@
+<div class="rankings">
+  <div class="container">
+    <div class="controls">
+      <div class="group tabs">
+        <button [class.active]="tab() === 'users'" (click)="setTab('users')">Users</button>
+        <button [class.active]="tab() === 'markers'" (click)="setTab('markers')">Markers</button>
+      </div>
+      <div class="group subtabs">
+        <button [class.active]="period() === 'month'" (click)="setPeriod('month')">Month</button>
+        <button [class.active]="period() === 'year'" (click)="setPeriod('year')">Year</button>
+        <button [class.active]="period() === 'all'" (click)="setPeriod('all')">All time</button>
+      </div>
+    </div>
+
+    <div class="explainer">
+      <mat-icon class="info">info</mat-icon>
+      <span *ngIf="tab() === 'users'">
+        Ranked by activity: <b>markers created</b> (weight 1.0) + <b>ratings given</b> (weight 0.25).
+      </span>
+      <span *ngIf="tab() === 'markers'">
+        Ranked by rating confidence using the <b>Wilson score</b> on 1–5 star votes.
+      </span>
+      <button class="link" (click)="toggleDetails()">
+        {{ showDetails() ? 'Hide details' : 'Show details' }}
+      </button>
+    </div>
+
+    <section *ngIf="tab() === 'users'">
+      <ng-container *ngIf="!usersError(); else usersErr">
+        <ul class="list">
+          <li *ngFor="let u of users(); let i = index; trackBy: trackUser" class="row">
+            <div class="cell rank">#{{ i + 1 }}</div>
+
+            <a class="cell who link btn-like"
+               (click)="goToUser(u.userId)"
+               [attr.aria-label]="'Open profile of ' + (u.username || 'user')">
+              <img class="avatar" [src]="u.avatarUrl || defaultAvatar" alt="avatar">
+              <div class="name">{{ u.username || '(unknown user)' }}</div>
+            </a>
+
+            <div class="cell metric">
+              <mat-chip class="metric-chip">
+                <mat-icon>place</mat-icon>
+                <span class="label">Markers</span>
+                <span class="value">{{ u.markersCreated }}</span>
+              </mat-chip>
+            </div>
+
+            <div class="cell metric">
+              <mat-chip class="metric-chip">
+                <mat-icon>star</mat-icon>
+                <span class="label">Ratings</span>
+                <span class="value">{{ u.ratingsGiven }}</span>
+              </mat-chip>
+            </div>
+
+            <div class="cell metric" [class.hidden]="!showDetails()">
+              <mat-chip class="metric-chip accent">
+                <mat-icon>equalizer</mat-icon>
+                <span class="label">Activity</span>
+                <span class="value">{{ u.score | number:'1.0-2' }}</span>
+              </mat-chip>
+            </div>
+          </li>
+        </ul>
+
+        <div class="actions">
+          <button (click)="loadMoreUsers(period())" [disabled]="usersLoading() || usersNext() === null">
+            {{ usersNext() === null ? 'No more' : (usersLoading() ? 'Loading…' : 'Load more') }}
+          </button>
+        </div>
+      </ng-container>
+      <ng-template #usersErr>
+        <p class="error">{{ usersError() }}</p>
+      </ng-template>
+    </section>
+
+    <section *ngIf="tab() === 'markers'">
+      <ng-container *ngIf="!markersError(); else markersErr">
+        <ul class="list">
+          <li *ngFor="let m of markers(); let i = index; trackBy: trackMarker" class="row">
+            <div class="cell rank">#{{ i + 1 }}</div>
+
+            <button class="cell who link btn-like"
+                    (click)="goToMarker(m)"
+                    [attr.aria-label]="'Open marker ' + m.title">
+              <div class="name">{{ m.title }}</div>
+            </button>
+
+            <div class="cell metric">
+              <mat-chip class="metric-chip">
+                <mat-icon>how_to_vote</mat-icon>
+                <span class="label">Votes</span>
+                <span class="value">{{ m.ratingsCount }}</span>
+              </mat-chip>
+            </div>
+
+            <div class="cell metric hidden"></div>
+
+            <div class="cell metric" [class.hidden]="!showDetails()">
+              <mat-chip class="metric-chip accent">
+                <mat-icon>insights</mat-icon>
+                <span class="label">Confidence</span>
+                <span class="value">{{ m.wilson | number:'1.0-4' }}</span>
+              </mat-chip>
+            </div>
+          </li>
+        </ul>
+
+        <div class="actions">
+          <button (click)="loadMoreMarkers(period())" [disabled]="markersLoading() || markersNext() === null">
+            {{ markersNext() === null ? 'No more' : (markersLoading() ? 'Loading…' : 'Load more') }}
+          </button>
+        </div>
+      </ng-container>
+      <ng-template #markersErr>
+        <p class="error">{{ markersError() }}</p>
+      </ng-template>
+    </section>
+  </div>
+</div>

--- a/src/app/components/rankings-page/rankings-page.component.spec.ts
+++ b/src/app/components/rankings-page/rankings-page.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RankingsPageComponent } from './rankings-page.component';
+
+describe('RankingsPageComponent', () => {
+  let component: RankingsPageComponent;
+  let fixture: ComponentFixture<RankingsPageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [RankingsPageComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(RankingsPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/rankings-page/rankings-page.component.ts
+++ b/src/app/components/rankings-page/rankings-page.component.ts
@@ -1,0 +1,121 @@
+import {Component, OnInit, signal} from '@angular/core';
+import {MarkerRankingItem, Period, UserRankingItem} from '../../models/rankings.models';
+import {RankingsService} from '../../services/rankings.service';
+import {CommonModule} from '@angular/common';
+import {MatIconModule} from '@angular/material/icon';
+import {MatChipsModule} from '@angular/material/chips';
+import {NavegationService} from '../../services/navegation.service';
+
+type Tab = 'users' | 'markers';
+
+@Component({
+  selector: 'app-rankings-page',
+  standalone: true,
+  imports: [CommonModule, MatIconModule, MatChipsModule, MatIconModule],
+  templateUrl: './rankings-page.component.html',
+  styleUrl: './rankings-page.component.css'
+})
+export class RankingsPageComponent implements OnInit {
+  defaultAvatar = '/default-avatar.jpg';
+
+  constructor(private api: RankingsService, private nav: NavegationService) {
+  }
+
+  tab = signal<Tab>('users');
+  period = signal<Period>('month');
+
+  users = signal<UserRankingItem[]>([]);
+  usersNext = signal<number | null>(0);
+  usersLoading = signal(false);
+  usersError = signal<string | null>(null);
+
+  markers = signal<MarkerRankingItem[]>([]);
+  markersNext = signal<number | null>(0);
+  markersLoading = signal(false);
+  markersError = signal<string | null>(null);
+
+  ngOnInit(): void {
+    this.reloadUsers(this.period());
+  }
+
+  setTab(t: Tab) {
+    if (this.tab() === t) return;
+    this.tab.set(t);
+    if (t === 'users') this.reloadUsers(this.period());
+    else this.reloadMarkers(this.period());
+  }
+
+  setPeriod(p: Period) {
+    if (this.period() === p) return;
+    this.period.set(p);
+    if (this.tab() === 'users') this.reloadUsers(p);
+    else this.reloadMarkers(p);
+  }
+
+  reloadUsers(p: Period) {
+    this.users.set([]);
+    this.usersNext.set(0);
+    this.loadMoreUsers(p);
+  }
+
+  loadMoreUsers(p: Period) {
+    const next = this.usersNext();
+    if (next === null || this.usersLoading()) return;
+    this.usersLoading.set(true);
+    this.usersError.set(null);
+
+    this.api.getUserRanking(p, 20, next).subscribe({
+      next: (res) => {
+        this.users.update(arr => arr.concat(res.items ?? []));
+        this.usersNext.set(res.nextOffset ?? null);
+        this.usersLoading.set(false);
+      },
+      error: (err) => {
+        this.usersError.set(err?.error?.message ?? 'Could not load users ranking');
+        this.usersLoading.set(false);
+      }
+    });
+  }
+
+  reloadMarkers(p: Period) {
+    this.markers.set([]);
+    this.markersNext.set(0);
+    this.loadMoreMarkers(p);
+  }
+
+  loadMoreMarkers(p: Period) {
+    const next = this.markersNext();
+    if (next === null || this.markersLoading()) return;
+    this.markersLoading.set(true);
+    this.markersError.set(null);
+
+    this.api.getMarkerRanking(p, 20, next).subscribe({
+      next: (res) => {
+        this.markers.update(arr => arr.concat(res.items ?? []));
+        this.markersNext.set(res.nextOffset ?? null);
+        this.markersLoading.set(false);
+      },
+      error: (err) => {
+        this.markersError.set(err?.error?.message ?? 'Could not load markers ranking');
+        this.markersLoading.set(false);
+      }
+    });
+  }
+
+  showDetails = signal(false);
+
+  toggleDetails() {
+    this.showDetails.update(v => !v);
+  }
+
+  trackUser = (_: number, u: UserRankingItem) => u.userId;
+  trackMarker = (_: number, m: any) => (m.markerId ?? m.id);
+
+  goToUser(userId: number) {
+    this.nav.goToUserProfile(userId);
+  }
+
+  goToMarker(m: { markerId: number; lat?: number; lng?: number }) {
+    this.nav.focusMarker(m.markerId, (m.lat != null && m.lng != null) ? {lat: m.lat, lng: m.lng} : undefined);
+  }
+}

--- a/src/app/models/rankings.models.ts
+++ b/src/app/models/rankings.models.ts
@@ -1,0 +1,26 @@
+export type Period = 'month' | 'year' | 'all';
+
+export interface UserRankingItem {
+  userId: number;
+  username: string | null;
+  avatarUrl?: string | null;
+  authServerUserId?: string | null;
+  markersCreated: number;
+  ratingsGiven: number;
+  score: number;
+}
+
+export interface MarkerRankingItem {
+  markerId: number;
+  title: string;
+  lat: number;
+  lng: number;
+  ratingsCount: number;
+  avgNorm?: number;
+  wilson: number;
+}
+
+export interface Paginated<T> {
+  items: T[];
+  nextOffset?: number | null;
+}

--- a/src/app/services/navegation.service.spec.ts
+++ b/src/app/services/navegation.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NavegationService } from './navegation.service';
+
+describe('NavegationService', () => {
+  let service: NavegationService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NavegationService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/navegation.service.ts
+++ b/src/app/services/navegation.service.ts
@@ -1,0 +1,26 @@
+import {inject, Injectable} from '@angular/core';
+import {Router} from '@angular/router';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class NavegationService {
+  private router = inject(Router);
+
+  goToUserProfile(userId: number) {
+    this.router.navigate(['/user', userId]);
+  }
+
+  focusMarker(markerId: number, coords?: { lat: number; lng: number }, zoom = 16) {
+    const outlets = {detail: ['marker', markerId]};
+    const queryParams: any = {focusMarker: markerId};
+
+    if (coords?.lat != null && coords?.lng != null) {
+      queryParams.lat = coords.lat;
+      queryParams.lng = coords.lng;
+      queryParams.zoom = zoom;
+    }
+
+    this.router.navigate(['/home', {outlets}], {queryParams});
+  }
+}

--- a/src/app/services/rankings.service.spec.ts
+++ b/src/app/services/rankings.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { RankingsService } from './rankings.service';
+
+describe('RankingsService', () => {
+  let service: RankingsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(RankingsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/rankings.service.ts
+++ b/src/app/services/rankings.service.ts
@@ -1,0 +1,29 @@
+import {inject, Injectable} from '@angular/core';
+import {environment} from '../../environments/environment';
+import {HttpClient, HttpParams} from '@angular/common/http';
+import {MarkerRankingItem, Paginated, Period, UserRankingItem} from '../models/rankings.models';
+import {Observable} from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class RankingsService {
+  private http = inject(HttpClient);
+  private base = environment.resourceApi;
+
+  getUserRanking(period: Period, limit = 20, offset = 0): Observable<Paginated<UserRankingItem>> {
+    const params = new HttpParams()
+      .set('period', period)
+      .set('limit', limit)
+      .set('offset', offset);
+    return this.http.get<Paginated<UserRankingItem>>(`${this.base}/rankings/users`, {params});
+  }
+
+  getMarkerRanking(period: Period, limit = 20, offset = 0): Observable<Paginated<MarkerRankingItem>> {
+    const params = new HttpParams()
+      .set('period', period)
+      .set('limit', limit)
+      .set('offset', offset);
+    return this.http.get<Paginated<MarkerRankingItem>>(`${this.base}/rankings/markers`, {params});
+  }
+}


### PR DESCRIPTION
A new component was created to add rankings to the user interface. 
The template has an users and a markers tab and you can also choose between the month, year and all time ranking. 
Some models were added to receive data from the backend. 
A service was created to call respective endpoints. 
A second service was created to navigate to user profiles and markers in the map.